### PR TITLE
refactor(p3c-common): 重构快速修复功能

### DIFF
--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AliQuickFix.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AliQuickFix.kt
@@ -16,9 +16,6 @@
 package com.alibaba.p3c.idea.quickfix
 
 import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
@@ -41,7 +38,7 @@ interface AliQuickFix : LocalQuickFix {
     companion object {
         const val groupName = "Ali QuickFix"
 
-        fun doQuickFixNew(
+        fun doQuickFix(
             newIdentifier: String,
             project: Project,
             psiIdentifier: PsiIdentifier
@@ -59,37 +56,6 @@ interface AliQuickFix : LocalQuickFix {
             commitDocumentIfNeeded(psiFile, project)
             val psiFacade = JavaPsiFacade.getInstance(project)
             val factory = psiFacade.elementFactory
-            psiFile.findElementAt(offset)?.replace(factory.createIdentifier(newIdentifier))
-        }
-
-        fun doQuickFix(newIdentifier: String, project: Project, psiIdentifier: PsiIdentifier) {
-            val offset = psiIdentifier.textOffset
-            val cannotFix = psiIdentifier.parent !is PsiMember
-                    && !(psiIdentifier.parent is PsiLocalVariable || psiIdentifier.parent is PsiParameter)
-            if (cannotFix) {
-                return
-            }
-
-            val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
-            editor.caretModel.moveToOffset(psiIdentifier.textOffset)
-            val anAction = ActionManager.getInstance().getAction("RenameElement")
-            val psiFile = psiIdentifier.containingFile
-            commitDocumentIfNeeded(psiFile, project)
-            val event = AnActionEvent.createFromDataContext("MainMenu", anAction.templatePresentation) {
-                when (it) {
-                    CommonDataKeys.PROJECT.name -> project
-                    CommonDataKeys.EDITOR.name -> editor
-                    CommonDataKeys.PSI_FILE.name -> psiFile
-                    CommonDataKeys.PSI_ELEMENT.name -> psiIdentifier.parent
-                    else -> null
-                }
-            }
-            val psiFacade = JavaPsiFacade.getInstance(project)
-            val factory = psiFacade.elementFactory
-
-            anAction.actionPerformed(event)
-
-            // origin PsiIdentifier is unavailable
             psiFile.findElementAt(offset)?.replace(factory.createIdentifier(newIdentifier))
         }
 

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AvoidStartWithDollarAndUnderLineNamingQuickFix.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/AvoidStartWithDollarAndUnderLineNamingQuickFix.kt
@@ -44,6 +44,6 @@ object AvoidStartWithDollarAndUnderLineNamingQuickFix : AliQuickFix {
         if (resultName.toLongOrNull() != null) {
             return
         }
-        AliQuickFix.doQuickFixNew(resultName, project, psiIdentifier)
+        AliQuickFix.doQuickFix(resultName, project, psiIdentifier)
     }
 }

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/ConstantFieldShouldBeUpperCaseQuickFix.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/ConstantFieldShouldBeUpperCaseQuickFix.kt
@@ -44,7 +44,7 @@ object ConstantFieldShouldBeUpperCaseQuickFix : AliQuickFix {
             separateCamelCase(it).uppercase(Locale.getDefault())
         }
 
-        AliQuickFix.doQuickFixNew(resultName, project, psiIdentifier)
+        AliQuickFix.doQuickFix(resultName, project, psiIdentifier)
     }
 
     private fun separateCamelCase(name: String): String {

--- a/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/LowerCamelCaseVariableNamingQuickFix.kt
+++ b/idea-plugin/p3c-common/src/main/kotlin/com/alibaba/p3c/idea/quickfix/LowerCamelCaseVariableNamingQuickFix.kt
@@ -41,7 +41,7 @@ object LowerCamelCaseVariableNamingQuickFix : AliQuickFix {
         val psiIdentifier = descriptor.psiElement as? PsiIdentifier ?: return
         val identifier = psiIdentifier.text
         val resultName = toLowerCamelCase(identifier)
-        AliQuickFix.doQuickFixNew(resultName, project, psiIdentifier)
+        AliQuickFix.doQuickFix(resultName, project, psiIdentifier)
     }
 
     private fun toLowerCamelCase(identifier: String): String {


### PR DESCRIPTION
- 重命名 doQuickFixNew 函数为 doQuickFix，简化函数名称
- 删除未使用的导入语句，清理代码
- 更新相关文件中的函数调用，以适应修改后的函数名称